### PR TITLE
HealthCheckRegistry bean auto-configuration

### DIFF
--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckBean.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.astefanutti.metrics.cdi.se.HealthCheckBean.NAME;
+
+@ApplicationScoped
+@Named(NAME)
+public class HealthCheckBean extends HealthCheck {
+
+	static final String NAME = "HealthCheckBean";
+
+	private AtomicLong checkCount = new AtomicLong(0l);
+
+	@Override
+	public Result check() {
+		checkCount.incrementAndGet();
+		return Result.healthy();
+	}
+
+	public Long getCheckCount() {
+		return checkCount.get();
+	}
+}

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerFieldBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerFieldBean.java
@@ -16,10 +16,13 @@
 package io.astefanutti.metrics.cdi.se;
 
 import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Qualifier;
 
 @ApplicationScoped
 public class HealthCheckProducerFieldBean {
@@ -38,6 +41,14 @@ public class HealthCheckProducerFieldBean {
 		@Override
 		protected Result check() throws Exception {
 			return Result.unhealthy("check2");
+		}
+	};
+
+	@Produces
+	private final HealthCheck check3 = new HealthCheck() {
+		@Override
+		protected Result check() throws Exception {
+			return Result.healthy("check3");
 		}
 	};
 }

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerFieldBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerFieldBean.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+@ApplicationScoped
+public class HealthCheckProducerFieldBean {
+	@Produces
+	@Named("check1")
+	private final HealthCheck check1 = new HealthCheck() {
+		@Override
+		protected Result check() {
+			return Result.healthy("check1");
+		}
+	};
+
+	@Produces
+	@Named("check2")
+	private final HealthCheck check2 = new HealthCheck() {
+		@Override
+		protected Result check() throws Exception {
+			return Result.unhealthy("check2");
+		}
+	};
+}

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerMethodBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerMethodBean.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+@ApplicationScoped
+public class HealthCheckProducerMethodBean {
+	@Produces
+	@Named("check1")
+	HealthCheck aHealthyCheck() {
+		return new HealthCheck() {
+			@Override
+			protected Result check() {
+				return Result.healthy("check1");
+			}
+		};
+	}
+
+	@Produces
+	@Named("check2")
+	HealthCheck anUnhealthyCheck() {
+		return new HealthCheck() {
+			@Override
+			protected Result check() throws Exception {
+				return Result.unhealthy("check2");
+			}
+		};
+	}
+}

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerMethodBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckProducerMethodBean.java
@@ -16,9 +16,11 @@
 package io.astefanutti.metrics.cdi.se;
 
 import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
 import javax.inject.Named;
 
 @ApplicationScoped
@@ -43,5 +45,18 @@ public class HealthCheckProducerMethodBean {
 				return Result.unhealthy("check2");
 			}
 		};
+	}
+
+	@Produces
+	@Named("not_registered_healthcheck")
+	HealthCheck anInjectedCheck(HealthCheckRegistry registry, InjectionPoint ip) {
+		HealthCheck check3 = new HealthCheck() {
+			@Override
+			protected Result check() throws Exception {
+				return Result.healthy("check3");
+			}
+		};
+		registry.register("check3", check3);
+		return check3;
 	}
 }

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBean.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+public class HealthCheckRegistryProducerFieldBean {
+
+	@Produces
+	@ApplicationScoped
+	private final HealthCheckRegistry registry = new HealthCheckRegistry();
+}

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBean.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+public class HealthCheckRegistryProducerMethodBean {
+	@Produces
+	@ApplicationScoped
+	HealthCheckRegistry registry() {
+		HealthCheckRegistry registry = new HealthCheckRegistry();
+		return registry;
+	}
+
+}

--- a/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/UnnamedHealthCheckBean.java
+++ b/envs/se/src/main/java/io/astefanutti/metrics/cdi/se/UnnamedHealthCheckBean.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import com.codahale.metrics.health.HealthCheck;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.astefanutti.metrics.cdi.se.HealthCheckBean.NAME;
+
+@ApplicationScoped
+public class UnnamedHealthCheckBean extends HealthCheckBean {
+}

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckFieldProducerTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckFieldProducerTest.java
@@ -56,7 +56,7 @@ public class HealthCheckFieldProducerTest {
 	@InSequence(1)
 	public void healthChecksRegistered() {
 		assertThat("HealthChecks are not registered correctly", registry.getNames(),
-				containsInRelativeOrder("check1", "check2"));
+				containsInRelativeOrder("check1", "check2", "io.astefanutti.metrics.cdi.se.HealthCheckProducerFieldBean.check3"));
 
 		SortedMap<String, Result> results = registry.runHealthChecks();
 
@@ -66,6 +66,9 @@ public class HealthCheckFieldProducerTest {
 
 		assertThat("check2 did not execute", results, hasKey("check2"));
 		assertThat("check2 did not fail", results.get("check2").isHealthy(), is(false));
+
+		assertThat("check3 did not execute", results, hasKey("io.astefanutti.metrics.cdi.se.HealthCheckProducerFieldBean.check3"));
+		assertThat("check3 did not pass", results.get("io.astefanutti.metrics.cdi.se.HealthCheckProducerFieldBean.check3").isHealthy(), is(true));
 	}
 
 }

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckFieldProducerTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckFieldProducerTest.java
@@ -15,7 +15,6 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import io.astefanutti.metrics.cdi.MetricsExtension;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -29,29 +28,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Qualifier;
+import java.util.SortedMap;
 
-import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
+import static com.codahale.metrics.health.HealthCheck.Result;
+import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-
 @RunWith(Arquillian.class)
-public class HealthCheckRegistryProducerFieldBeanTest {
-
+public class HealthCheckFieldProducerTest {
 	@Deployment
 	public static Archive<?> createTestArchive() {
 		return ShrinkWrap.create(JavaArchive.class)
-				// HealthCheck registry bean
-				.addClass(HealthCheckRegistryProducerFieldBean.class)
 				// Test bean
-				.addClass(HealthCheckBean.class)
-				.addClass(UnnamedHealthCheckBean.class)
-				// MetricsCDI extension
+				.addClass(HealthCheckProducerFieldBean.class)
+				// Metrics CDI Extension
 				.addPackage(MetricsExtension.class.getPackage())
 				// Bean archive deployment descriptor
 				.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
@@ -60,32 +52,22 @@ public class HealthCheckRegistryProducerFieldBeanTest {
 	@Inject
 	private HealthCheckRegistry registry;
 
-	@Inject
-	private UnnamedHealthCheckBean unnamedHealthCheckBean;
-
-	@Inject
-	@Named("HealthCheckBean")
-	private HealthCheckBean bean;
-
 	@Test
 	@InSequence(1)
-	public void healthCheckNotCalledYet() {
-		assertThat("HealthCheck is not registered correctly", registry.getNames(), allOf(contains(bean.NAME, UnnamedHealthCheckBean.class.getName())));
-		HealthCheck check = registry.getHealthCheck(bean.NAME);
+	public void healthChecksRegistered() {
+		assertThat("HealthChecks are not registered correctly", registry.getNames(),
+				containsInRelativeOrder("check1", "check2"));
+
+		SortedMap<String, Result> results = registry.runHealthChecks();
 
 
-		assertThat("Execution hasn't occurred yet.", bean.getCheckCount(), is(equalTo(0l)));
+		assertThat("check1 did not execute", results, hasKey("check1"));
+		assertThat("check1 did not pass", results.get("check1").isHealthy(), is(true));
 
+		assertThat("check2 did not execute", results, hasKey("check2"));
+		assertThat("check2 did not fail", results.get("check2").isHealthy(), is(false));
 	}
 
-	@Test
-	@InSequence(2)
-	public void healthCheckInvoked() {
-		assertThat("HealthCheck is not registered correctly", registry.getNames(), allOf(contains(bean.NAME, UnnamedHealthCheckBean.class.getName())));
-
-		registry.runHealthChecks();
-
-		assertThat("Execution count is incorrect.", bean.getCheckCount(), is(equalTo(1l)));
-		assertThat("Execution count on unnamed bean is incorrect.", unnamedHealthCheckBean.getCheckCount(), is(equalTo(1l)));
-	}
 }
+
+

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckMethodProducerTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckMethodProducerTest.java
@@ -29,8 +29,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import java.util.SortedMap;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInRelativeOrder;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -53,8 +56,25 @@ public class HealthCheckMethodProducerTest {
 	@Inject
 	private HealthCheckRegistry registry;
 
+	@Inject
+	@Named("not_registered_healthcheck")
+	private HealthCheck not_registerd_healthcheck;
+
 	@Test
 	@InSequence(1)
+	public void healthChecksRegisteredProperly() {
+		assertThat("HealthChecks are not registered correctly", registry.getNames(),
+			contains(
+					"check1", "check2", "check3"
+			)
+		);
+		assertThat("HealthChecks are not registered correctly", registry.getNames(),
+			not(contains("not_registered_healthcheck"))
+		);
+	}
+
+	@Test
+	@InSequence(2)
 	public void healthChecksRegistered() {
 		assertThat("HealthChecks are not registered correctly", registry.getNames(),
 				containsInRelativeOrder("check1", "check2"));

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBeanTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBeanTest.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+public class HealthCheckRegistryProducerFieldBeanTest {
+}

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBeanTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBeanTest.java
@@ -30,12 +30,10 @@ import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Qualifier;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBeanTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerFieldBeanTest.java
@@ -15,5 +15,67 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.astefanutti.metrics.cdi.MetricsExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+@RunWith(Arquillian.class)
 public class HealthCheckRegistryProducerFieldBeanTest {
+
+	@Deployment
+	static Archive<?> createTestArchive() {
+		return ShrinkWrap.create(JavaArchive.class)
+				// HealthCheck registry bean
+				.addClass(HealthCheckRegistryProducerFieldBean.class)
+				// Test bean
+				.addClass(HealthCheckBean.class)
+				// MetricsCDI extension
+				.addPackage(MetricsExtension.class.getPackage())
+				// Bean archive deployment descriptor
+				.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+	}
+
+	@Inject
+	private HealthCheckRegistry registry;
+
+	@Inject
+	private HealthCheckBean bean;
+
+	@Test
+	@InSequence(1)
+	public void healthCheckNotCalledYet() {
+		assertThat("HealthCheck is not registered correctly", registry.getNames(), contains(bean.NAME));
+		HealthCheck check = registry.getHealthCheck(bean.NAME);
+
+		assertThat("Execution hasn't occurred yet.", bean.getCheckCount(), is(equalTo(0l)));
+	}
+
+	@Test
+	@InSequence(2)
+	public void healthCheckInvoked() {
+		assertThat("HealthCheck is not registered correctly", registry.getNames(), contains(bean.NAME));
+		HealthCheck check = registry.getHealthCheck(bean.NAME);
+
+		registry.runHealthChecks();
+
+		assertThat("Execution count is incorrect.", bean.getCheckCount(), is(equalTo(1l)));
+	}
 }

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBeanTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBeanTest.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.astefanutti.metrics.cdi.se;
+
+public class HealthCheckRegistryProducerMethodBeanTest {
+}

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBeanTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBeanTest.java
@@ -15,5 +15,64 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.astefanutti.metrics.cdi.MetricsExtension;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Arquillian.class)
 public class HealthCheckRegistryProducerMethodBeanTest {
+	@Deployment
+	static Archive<?> createTestArchive() {
+		return ShrinkWrap.create(JavaArchive.class)
+				// HealthCheck registry bean
+				.addClass(HealthCheckRegistryProducerMethodBean.class)
+				// Test bean
+				.addClass(HealthCheckBean.class)
+				// MetricsCDI Extension
+				.addPackage(MetricsExtension.class.getPackage())
+				// Bean archive deployment Descriptior
+				.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+	}
+
+	@Inject
+	private HealthCheckRegistry registry;
+
+	@Inject
+	private HealthCheckBean bean;
+
+	@Test
+	@InSequence(1)
+	public void healthCheckNotCalledYet() {
+		assertThat("HealthCheck is not registered correctly", registry.getNames(), contains(bean.NAME));
+		HealthCheck check = registry.getHealthCheck(bean.NAME);
+
+		assertThat("Execution hasn't occurred yet.", bean.getCheckCount(), is(equalTo(0l)));
+	}
+
+	@Test
+	@InSequence(2)
+	public void healthCheckInvoked() {
+		assertThat("HealthCheck is not registered correctly", registry.getNames(), contains(bean.NAME));
+		HealthCheck check = registry.getHealthCheck(bean.NAME);
+
+		registry.runHealthChecks();
+
+		assertThat("Execution count is incorrect.", bean.getCheckCount(), is(equalTo(1l)));
+	}
 }

--- a/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBeanTest.java
+++ b/envs/se/src/test/java/io/astefanutti/metrics/cdi/se/HealthCheckRegistryProducerMethodBeanTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertThat;
 @RunWith(Arquillian.class)
 public class HealthCheckRegistryProducerMethodBeanTest {
 	@Deployment
-	static Archive<?> createTestArchive() {
+	public static Archive<?> createTestArchive() {
 		return ShrinkWrap.create(JavaArchive.class)
 				// HealthCheck registry bean
 				.addClass(HealthCheckRegistryProducerMethodBean.class)

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -47,6 +47,10 @@
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-annotation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-healthchecks</artifactId>
+        </dependency>
 
         <!-- provided dependencies -->
 

--- a/impl/src/main/java/io/astefanutti/metrics/cdi/DefaultRegistryBean.java
+++ b/impl/src/main/java/io/astefanutti/metrics/cdi/DefaultRegistryBean.java
@@ -136,6 +136,6 @@ import java.util.Set;
 
     @Override
     public String getId() {
-        return getClass().getName();
+        return getClass().getName() + "#" + name;
     }
 }

--- a/impl/src/main/java/io/astefanutti/metrics/cdi/DefaultRegistryBean.java
+++ b/impl/src/main/java/io/astefanutti/metrics/cdi/DefaultRegistryBean.java
@@ -61,11 +61,11 @@ import java.util.Set;
 
     /** Factory method to return properly typed and described RegistryBean */
     static DefaultRegistryBean<MetricRegistry> createDefaultMetricRegistry(BeanManager manager) {
-        return new DefaultRegistryBean<>(manager, MetricRegistry.class, "metric-registry", "Default Metric Registry Bean");
+        return new DefaultRegistryBean<MetricRegistry>(manager, MetricRegistry.class, "metric-registry", "Default Metric Registry Bean");
     }
 
     static DefaultRegistryBean<HealthCheckRegistry> createDefaultHealthCheckRegistry(BeanManager manager) {
-        return new DefaultRegistryBean<>(manager, HealthCheckRegistry.class, "health-check-registry", "Default Health Check Registry Bean");
+        return new DefaultRegistryBean<HealthCheckRegistry>(manager, HealthCheckRegistry.class, "health-check-registry", "Default Health Check Registry Bean");
     }
 
     @Override

--- a/impl/src/main/java/io/astefanutti/metrics/cdi/MetricsExtension.java
+++ b/impl/src/main/java/io/astefanutti/metrics/cdi/MetricsExtension.java
@@ -146,7 +146,7 @@ public class MetricsExtension implements Extension {
 
             String name = bean.getKey().getName();
             if (name == null) {
-                name = bean.getKey().getBeanClass().getName();
+                name = bean.getKey().getBeanClass().getName() + "." + bean.getValue().getJavaMember().getName();
             }
             healthCheckRegistry.register(name, (HealthCheck) getReference(manager, bean.getValue().getBaseType(), bean.getKey()));
         }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <metrics.version>3.2.4</metrics.version>
+        <metrics.version>4.0.3</metrics.version>
         <cdi.version>1.2</cdi.version>
         <cdi2.version>2.0</cdi2.version>
         <javaee7.version>7.0</javaee7.version>
@@ -208,6 +208,17 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-annotation</artifactId>
+                <version>${metrics.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-healthchecks</artifactId>
                 <version>${metrics.version}</version>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
#13 Implements auto-configuration and registration for HealthCheck beans into a HealthCheckRegistry.

Also relevant: Bumps to upstream metrics 4.0.3

* Handles field / method / scoped declarations for HealthCheck implementations.
* Handles creation of an `@Default HealthCheckRegistry` if none is detected on the classpath or produced from a field / method.

I wasn't completely certain about the way I did the after validation handling of HealthCheck instances. I think my logic for not ignoring @Default but not re-registering contextualized beans seems to work.